### PR TITLE
fix: Fix indexing to use 1-based and use proper type in tests

### DIFF
--- a/ext/BraketSimulatorPythonExt/BraketSimulatorPythonExt.jl
+++ b/ext/BraketSimulatorPythonExt/BraketSimulatorPythonExt.jl
@@ -259,7 +259,7 @@ end
 
 function simulate(
     simulator::AbstractSimulator,
-    task_specs::Union{PyList{Any},NTuple{N,PyIterable},Py},
+    task_specs::Union{PyList{Any},NTuple{N,PyIterable}},
     args...;
     input::Union{PyList{Any},PyDict{Any,Any},Py}=PyDict{Any,Any}(),
     kwargs...,


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The Julia wrapper around Python `list`s is `PyList`. In the tests, we were constructing a raw Python `list` (which has type `Py`) and passing it to the extension method. This PR tightens up the acceptable types in the extension method and fixes the indexing.

*Testing done:* Unit tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
