### PR TITLE
fix: DM noise warning

### DIFF
--- a/src/validation.jl
+++ b/src/validation.jl
@@ -76,7 +76,7 @@ function _validate_ir_instructions_compatibility(
     circuit::Union{Program,Circuit},
     supported_operations,
 ) where {D<:AbstractSimulator}
-    circuit_instruction_names = map(ix->replace(replace(lowercase(string(typeof(ix.operator))), "_"=>""), "braket."=>""), circuit.instructions)
+    circuit_instruction_names = map(ix->replace(lowercase(string(typeof(ix.operator))), "_"=>"", "braket."=>""), circuit.instructions)
     supported_instructions    = Set(map(op->replace(lowercase(op), "_"=>""), supported_operations))
     no_noise = true
     for name in circuit_instruction_names

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -76,7 +76,7 @@ function _validate_ir_instructions_compatibility(
     circuit::Union{Program,Circuit},
     supported_operations,
 ) where {D<:AbstractSimulator}
-    circuit_instruction_names = map(ix->replace(lowercase(string(typeof(ix.operator))), "_"=>""), circuit.instructions)
+    circuit_instruction_names = map(ix->replace(replace(lowercase(string(typeof(ix.operator))), "_"=>""), "braket."=>""), circuit.instructions)
     supported_instructions    = Set(map(op->replace(lowercase(op), "_"=>""), supported_operations))
     no_noise = true
     for name in circuit_instruction_names


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The DM simulator would always output the warning that there was no noise in the circuit (even when there is). This seems to be because when we get the types from the circuit instructions they are all prefixed with "braket.". I've removed the prefix.

*Testing done:*

Tested with noisy circuit to verify the warning message is no longer output.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
