### PR TITLE
fix: Set max parallel to 32 or nthreads, whichever is smaller

### DIFF
--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -342,7 +342,7 @@ end
         
         todo_tasks_ch = Channel{Int}(ch->foreach(ix->put!(ch, ix), 1:n_tasks), n_tasks)
 
-        max_parallel_threads = max_parallel > 0 ? max_parallel : 32
+        max_parallel_threads = max_parallel > 0 ? max_parallel : min(32, Threads.nthreads())
         n_task_threads = min(max_parallel_threads, n_tasks)
 
         results = Vector{Braket.GateModelTaskResult}(undef, n_tasks)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Cap the number of parallel tasks to whichever of 32 and the thread count is smaller, to avoid spawning too many tasks

*Testing done:* Unit tests passed. Ran a batch of 30 16-qubit circuits locally in 1.03s.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
