### PR TITLE
Fix origin of `run_multiple` issue by returning copies of sv/dm as appropriate

### DIFF
--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -353,7 +353,7 @@ end
 
         results = Vector{Braket.GateModelTaskResult}(undef, n_tasks)
         function process_work()
-            my_sim = copy(simulator)
+            my_sim = similar(simulator)
             while isready(todo_tasks_ch)
                 my_ix = -1
                 # need to lock the channel as it may become empty

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -273,17 +273,7 @@ end
             operations = vcat(operations, program.basis_rotation_instructions)
         end
         _validate_operation_qubits(vcat(operations, measure_ixs))
-        if simulator isa StateVectorSimulator
-            println("SV before reinit:")
-            println(simulator.state_vector)
-            flush(stdout)
-        end
         reinit!(simulator, n_qubits, shots)
-        if simulator isa StateVectorSimulator
-            println("SV after reinit:")
-            println(simulator.state_vector)
-            flush(stdout)
-        end
         simulator = evolve!(simulator, operations)
         analytic_results = shots == 0 && !isnothing(program.results) && !isempty(program.results)
         results = if analytic_results

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -353,7 +353,6 @@ end
 
         results = Vector{Braket.GateModelTaskResult}(undef, n_tasks)
         function process_work()
-            my_sim = similar(simulator)
             while isready(todo_tasks_ch)
                 my_ix = -1
                 # need to lock the channel as it may become empty
@@ -365,6 +364,7 @@ end
                 # if my_ix is still -1, the channel is empty and
                 # there's no more work to do
                 my_ix == -1 && break
+                my_sim = similar(simulator)
                 spec  = task_specs[my_ix]
                 input = inputs[my_ix]
                 results[my_ix] = simulate(my_sim, spec, shots; inputs=input)

--- a/src/dm_simulator.jl
+++ b/src/dm_simulator.jl
@@ -252,7 +252,7 @@ function expectation(
     return real(sum(diag(dm_copy)))
 end
 state_vector(dms::DensityMatrixSimulator)   = diag(dms.density_matrix)
-density_matrix(dms::DensityMatrixSimulator) = dms.density_matrix
+density_matrix(dms::DensityMatrixSimulator) = copy(dms.density_matrix)
 probabilities(dms::DensityMatrixSimulator)  = real.(diag(dms.density_matrix))
 
 function swap_bits(ix::Int, qubit_map::Dict{Int,Int})

--- a/src/sv_simulator.jl
+++ b/src/sv_simulator.jl
@@ -149,7 +149,7 @@ function evolve!(
     return svs
 end
 
-state_vector(svs::StateVectorSimulator) = svs.state_vector
+state_vector(svs::StateVectorSimulator) = copy(svs.state_vector)
 density_matrix(svs::StateVectorSimulator) =
     kron(svs.state_vector, adjoint(svs.state_vector))
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We need to copy the state vector/density matrix for the results so the underlying memory doesn't get modified during subsequent runs for the same sim

*Testing done:* Fixed `run_multiple` in python wrapper testing locally

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
