### PR TITLE
fix: Use the IR's inputs if it has them for OQ3

### DIFF
--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -252,8 +252,9 @@ end
         shots::Int = 0;
         kwargs...,
     )
-        inputs = get(kwargs, :inputs, circuit_ir.inputs)
-        inputs = isnothing(inputs) ? Dict{String, Float64}() : Dict{String, Any}(k=>v for (k,v) in inputs)
+        ir_inputs = isnothing(circuit_ir.inputs) || isempty(circuit_ir.inputs) ? Dict{String, Float64}() : circuit_ir.inputs 
+        inputs = get(kwargs, :inputs, ir_inputs)
+        inputs = isnothing(inputs) || isempty(inputs) ? ir_inputs : Dict{String, Any}(k=>v for (k,v) in inputs)
         circuit = Circuit(circuit_ir.source, inputs)
         measure_ixs = splice!(circuit.instructions, findall(ix->ix.operator isa Measure, circuit.instructions))
         measure_targets = (convert(Vector{Int}, measure.target) for measure in measure_ixs) 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Make sure not to use the inputs kwarg if it's provided but empty and the IR itself has inputs

*Testing done:* Tests passed locally, checked that this fixes the parallelized processing with PL notebook

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
