### PR TITLE
allow instruction on qubits after measurements if they are reset

### DIFF
--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -568,6 +568,33 @@ get_tol(shots::Int) = return (
         """
         @test_warn "reset expression encountered -- currently `reset` is a no-op" parse_qasm(qasm)
     end
+    @testset "Cannot apply instructions after measurement" begin
+
+        qasm = """
+        qubit[4] q;
+        bit[3] b;
+        x q[0];
+        b[0] = measure q[0];
+        x q[0];
+        """
+        @test_throws ErrorException("cannot apply instruction to measured qubits.") BraketSimulator.Circuit(qasm)
+    end
+    @testset "Can apply instructions after reset measurement" begin
+
+        qasm = """
+        qubit[4] q;
+        bit[3] b;
+        x q[0];
+        b[0] = measure q[0];
+        reset q[0];
+        x q[0];
+        """
+        circ = Circuit(qasm)
+        @test circ.instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0),
+                                    BraketSimulator.Instruction(BraketSimulator.Measure(), 0),
+                                    BraketSimulator.Instruction(BraketSimulator.Reset(), 0),
+                                    BraketSimulator.Instruction(BraketSimulator.X(), 0)]
+    end
     @testset "Gate call missing/extra args" begin
         qasm = """
         qubit[4] q;


### PR DESCRIPTION
**Issue #:**  #45 

**Description of changes:**
This PR introduces functionality that allows instructions to be applied to qubits after they have been measured, provided that the qubits are subsequently reset. The key addition is the `_check_if_measured_qubit_is_reset` function, which checks the circuit for measurement and reset instructions related to a specific qubit.

**Testing done:**
Currently, no tests have been implemented for this functionality. Further testing is needed to ensure the correctness of the changes.


#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.