### PR TITLE
Remove allocations for better performance from Python, cleanup 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BraketSimulator"
 uuid = "76d27892-9a0b-406c-98e4-7c178e9b3dff"
 authors = ["Katharine Hyatt <hyatkath@amazon.com> and contributors"]
-version = "0.0.3"
+version = "0.0.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/ext/BraketSimulatorPythonExt/BraketSimulatorPythonExt.jl
+++ b/ext/BraketSimulatorPythonExt/BraketSimulatorPythonExt.jl
@@ -6,20 +6,41 @@ using PrecompileTools
     using BraketSimulator, PythonCall, JSON3
 end
 
-using BraketSimulator: simulate
+using BraketSimulator: simulate, AbstractProgramResult
 
-function BraketSimulator.simulate(simulator, task_spec::String, inputs::Dict{String, Any}, shots::Int; kwargs...)
-    jl_specs   = BraketSimulator.OpenQasmProgram(BraketSimulator.braketSchemaHeader("braket.ir.openqasm.program", "1"), task_spec, inputs)
-    jl_results = simulate(simulator, jl_specs, shots; kwargs...)
-    json       = JSON3.write(jl_results)
-    return json
+function BraketSimulator.simulate(simulator_id::String, task_spec::String, py_inputs::String, shots::Int; kwargs...)
+    inputs    = JSON3.read(py_inputs, Dict{String, Any})
+    jl_spec   = BraketSimulator.OpenQasmProgram(BraketSimulator.braketSchemaHeader("braket.ir.openqasm.program", "1"), task_spec, inputs)
+    simulator = if simulator_id == "braket_sv_v2"
+        StateVectorSimulator(0, shots)
+    elseif simulator_id == "braket_dm_v2"
+        DensityMatrixSimulator(0, shots)
+    end
+    jl_results = @time "simulate" simulate(simulator, jl_spec, shots; kwargs...)
+    py_results = @time "JSON write" JSON3.write(jl_results)
+    # this is expensive due to allocations
+    simulator  = nothing
+    inputs     = nothing
+    jl_spec    = nothing
+    jl_results = nothing
+    return py_results
 end
-function BraketSimulator.simulate(simulator, task_specs::Vector{String}, inputs::Vector{Dict{String, Any}}, shots::Int; kwargs...)
-    jl_specs   = map(zip(task_specs, inputs)) do (task_spec, input)
+function BraketSimulator.simulate(simulator_id::String, task_specs::PyList, py_inputs::String, shots::Int; kwargs...)
+    inputs    = JSON3.read(py_inputs, Vector{Dict{String, Any}})
+    jl_specs  = map(zip(task_specs, inputs)) do (task_spec, input)
         BraketSimulator.OpenQasmProgram(BraketSimulator.braketSchemaHeader("braket.ir.openqasm.program", "1"), task_spec, input)
+    end
+    simulator = if simulator_id == "braket_sv_v2"
+        StateVectorSimulator(0, shots)
+    elseif simulator_id == "braket_dm_v2"
+        DensityMatrixSimulator(0, shots)
     end
     jl_results = simulate(simulator, jl_specs, shots; kwargs...)
     jsons      = [JSON3.write(r) for r in jl_results]
+    simulator  = nothing
+    jl_results = nothing
+    inputs     = nothing
+    jl_specs   = nothing
     return jsons
 end
 

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -152,26 +152,26 @@ function _generate_results(
     return results
 end
 
-_translate_result_type(r::IR.Amplitude, qc::Int)     = Amplitude(r.states)
-_translate_result_type(r::IR.StateVector, qc::Int)   = StateVector()
+_translate_result_type(r::IR.Amplitude)     = Amplitude(r.states)
+_translate_result_type(r::IR.StateVector)   = StateVector()
 # The IR result types support `nothing` as a valid option for the `targets` field,
 # however `Result`s represent this with an empty `QubitSet` for type
 # stability reasons. Here we take a `nothing` value for `targets` and translate it
 # to apply to all qubits.
-_translate_result_type(r::IR.DensityMatrix, qc::Int) = DensityMatrix(r.targets)
-_translate_result_type(r::IR.Probability, qc::Int)   = Probability(r.targets)
+_translate_result_type(r::IR.DensityMatrix) = DensityMatrix(r.targets)
+_translate_result_type(r::IR.Probability)   = Probability(r.targets)
 for (RT, IRT) in ((:Expectation, :(IR.Expectation)), (:Variance, :(IR.Variance)), (:Sample, :(IR.Sample)))
     @eval begin
-        function _translate_result_type(r::$IRT, qc::Int)
-            obs     = StructTypes.constructfrom(Observables.Observable, r.observable)
+        function _translate_result_type(r::$IRT)
+            obs = StructTypes.constructfrom(Observables.Observable, r.observable)
             $RT(obs, QubitSet(r.targets))
         end
     end
 end
-_translate_result_types(results::Vector{AbstractProgramResult}, qubit_count::Int) = map(result->_translate_result_type(result, qubit_count), results)
+_translate_result_types(results::Vector{AbstractProgramResult}) = map(_translate_result_type, results)
 
 function _compute_exact_results(d::AbstractSimulator, program::Program, qubit_count::Int)
-    result_types = _translate_result_types(program.results, qubit_count)
+    result_types = _translate_result_types(program.results)
     _validate_result_types_qubits_exist(result_types, qubit_count)
     return _generate_results(result_types, d)
 end
@@ -220,7 +220,7 @@ end
 Apply any `inputs` provided for the simulation. Return the `Program`
 (with bound parameters) and the qubit count of the circuit.
 """
-function _prepare_program(circuit_ir::Program, inputs::Dict{String, <:Any}, shots::Int) #nosemgrep
+function _prepare_program(circuit_ir::Program, inputs::Dict{String, <:Any}, shots::Int) # nosemgrep
     operations::Vector{Instruction} = circuit_ir.instructions
     symbol_inputs = Dict(Symbol(k) => v for (k, v) in inputs)
     operations    = [bind_value!(operation, symbol_inputs) for operation in operations]

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -154,10 +154,6 @@ end
 
 _translate_result_type(r::IR.Amplitude)     = Amplitude(r.states)
 _translate_result_type(r::IR.StateVector)   = StateVector()
-# The IR result types support `nothing` as a valid option for the `targets` field,
-# however `Result`s represent this with an empty `QubitSet` for type
-# stability reasons. Here we take a `nothing` value for `targets` and translate it
-# to apply to all qubits.
 _translate_result_type(r::IR.DensityMatrix) = DensityMatrix(r.targets)
 _translate_result_type(r::IR.Probability)   = Probability(r.targets)
 for (RT, IRT) in ((:Expectation, :(IR.Expectation)), (:Variance, :(IR.Variance)), (:Sample, :(IR.Sample)))

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -78,9 +78,9 @@ qubit_count(c::Circuit) = length(qubits(c))
 qubit_count(p::Program) = length(qubits(p))
 
 function Base.convert(::Type{Program}, c::Circuit)
-    lowered_rts = @time "\t\t\tlower rts in program" ir.(c.result_types, Val(:JAQCD))
-    header = @time "\t\t\tbuild header" braketSchemaHeader("braket.ir.jaqcd.program" ,"1")
-    return @time "\t\t\tput program together" Program(header, c.instructions, lowered_rts, c.basis_rotation_instructions)
+    lowered_rts = map(StructTypes.lower, c.result_types)
+    header = braketSchemaHeader("braket.ir.jaqcd.program" ,"1")
+    return Program(header, c.instructions, lowered_rts, c.basis_rotation_instructions)
 end
 Program(c::Circuit) = convert(Program, c)
 

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -77,7 +77,7 @@ julia> qubit_count(c)
 qubit_count(c::Circuit) = length(qubits(c))
 qubit_count(p::Program) = length(qubits(p))
 
-function Base.convert(::Type{Program}, c::Circuit)
+function Base.convert(::Type{Program}, c::Circuit) # nosemgrep
     lowered_rts = map(StructTypes.lower, c.result_types)
     header = braketSchemaHeader("braket.ir.jaqcd.program" ,"1")
     return Program(header, c.instructions, lowered_rts, c.basis_rotation_instructions)

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -77,7 +77,11 @@ julia> qubit_count(c)
 qubit_count(c::Circuit) = length(qubits(c))
 qubit_count(p::Program) = length(qubits(p))
 
-Base.convert(::Type{Program}, c::Circuit) = (basis_rotation_instructions!(c); return Program(braketSchemaHeader("braket.ir.jaqcd.program" ,"1"), c.instructions, ir.(c.result_types, Val(:JAQCD)), c.basis_rotation_instructions))
+function Base.convert(::Type{Program}, c::Circuit)
+    lowered_rts = @time "\t\t\tlower rts in program" ir.(c.result_types, Val(:JAQCD))
+    header = @time "\t\t\tbuild header" braketSchemaHeader("braket.ir.jaqcd.program" ,"1")
+    return @time "\t\t\tput program together" Program(header, c.instructions, lowered_rts, c.basis_rotation_instructions)
+end
 Program(c::Circuit) = convert(Program, c)
 
 extract_observable(rt::ObservableResult) = rt.observable

--- a/src/custom_gates.jl
+++ b/src/custom_gates.jl
@@ -5,15 +5,13 @@ mutable struct DoubleExcitation <: AngledGate{1}
         new(angle, Float64(pow_exponent))
 end
 qubit_count(::Type{DoubleExcitation}) = 4
-function matrix_rep_raw(g::DoubleExcitation)
-    cosϕ = cos(g.angle[1] / 2.0)
-    sinϕ = sin(g.angle[1] / 2.0)
-
+function matrix_rep_raw(g::DoubleExcitation, ϕ)
+    sθ, cθ = sincos(ϕ/2.0)
     mat = diagm(ones(ComplexF64, 16))
-    mat[4, 4]   = cosϕ
-    mat[13, 13] = cosϕ
-    mat[4, 13]  = -sinϕ
-    mat[13, 4]  = sinϕ
+    mat[4, 4]   = cθ
+    mat[13, 13] = cθ
+    mat[4, 13]  = -sθ
+    mat[13, 4]  = sθ
     return SMatrix{16,16,ComplexF64}(mat)
 end
 
@@ -24,11 +22,7 @@ mutable struct SingleExcitation <: AngledGate{1}
         new(angle, Float64(pow_exponent))
 end
 qubit_count(::Type{SingleExcitation}) = 2
-function matrix_rep_raw(g::SingleExcitation)
-    cosϕ = cos(g.angle[1] / 2.0)
-    sinϕ = sin(g.angle[1] / 2.0)
-    return SMatrix{4,4,ComplexF64}([1.0 0 0 0; 0 cosϕ sinϕ 0; 0 -sinϕ cosϕ 0; 0 0 0 1.0])
-end
+matrix_rep_raw(g::SingleExcitation, ϕ) = ((sθ, cθ) = sincos(ϕ/2.0); return SMatrix{4,4,ComplexF64}(complex(1.0), 0, 0, 0, 0, cθ, -sθ, 0, 0, sθ, cθ, 0, 0, 0, 0, complex(1.0)))
 """
     MultiRz(angle)
 

--- a/src/custom_gates.jl
+++ b/src/custom_gates.jl
@@ -5,7 +5,7 @@ mutable struct DoubleExcitation <: AngledGate{1}
         new(angle, Float64(pow_exponent))
 end
 qubit_count(::Type{DoubleExcitation}) = 4
-function matrix_rep_raw(g::DoubleExcitation, ϕ)
+function matrix_rep_raw(::DoubleExcitation, ϕ) # nosemgrep
     sθ, cθ = sincos(ϕ/2.0)
     mat = diagm(ones(ComplexF64, 16))
     mat[4, 4]   = cθ
@@ -22,7 +22,7 @@ mutable struct SingleExcitation <: AngledGate{1}
         new(angle, Float64(pow_exponent))
 end
 qubit_count(::Type{SingleExcitation}) = 2
-matrix_rep_raw(g::SingleExcitation, ϕ) = ((sθ, cθ) = sincos(ϕ/2.0); return SMatrix{4,4,ComplexF64}(complex(1.0), 0, 0, 0, 0, cθ, -sθ, 0, 0, sθ, cθ, 0, 0, 0, 0, complex(1.0)))
+matrix_rep_raw(::SingleExcitation, ϕ) = ((sθ, cθ) = sincos(ϕ/2.0); return SMatrix{4,4,ComplexF64}(complex(1.0), 0, 0, 0, 0, cθ, -sθ, 0, 0, sθ, cθ, 0, 0, 0, 0, complex(1.0)))
 """
     MultiRz(angle)
 

--- a/src/custom_gates.jl
+++ b/src/custom_gates.jl
@@ -6,8 +6,8 @@ mutable struct DoubleExcitation <: AngledGate{1}
 end
 qubit_count(::Type{DoubleExcitation}) = 4
 function matrix_rep_raw(::DoubleExcitation, ϕ) # nosemgrep
-    sθ, cθ = sincos(ϕ/2.0)
-    mat = diagm(ones(ComplexF64, 16))
+    sθ, cθ      = sincos(ϕ/2.0)
+    mat         = diagm(ones(ComplexF64, 16))
     mat[4, 4]   = cθ
     mat[13, 13] = cθ
     mat[4, 13]  = -sθ
@@ -89,13 +89,12 @@ function apply_gate!(
 ) where {T<:Complex}
     n_amps, endian_ts = get_amps_and_qubits(state_vec, t1, t2, t3, t4)
     ordered_ts = sort(collect(endian_ts))
-    cosϕ = cos(g.angle[1] / 2.0)
-    sinϕ = sin(g.angle[1] / 2.0)
+    sinϕ, cosϕ = sincos(g.angle[1] * g.pow_exponent / 2.0)
     e_t1, e_t2, e_t3, e_t4 = endian_ts
     Threads.@threads for ix = 0:div(n_amps, 2^4)-1
         padded_ix = pad_bits(ix, ordered_ts)
-        i0011 = flip_bits(padded_ix, (e_t3, e_t4)) + 1
-        i1100 = flip_bits(padded_ix, (e_t1, e_t2)) + 1
+        i0011     = flip_bits(padded_ix, (e_t3, e_t4)) + 1
+        i1100     = flip_bits(padded_ix, (e_t1, e_t2)) + 1
         @inbounds begin
             amp0011 = state_vec[i0011]
             amp1100 = state_vec[i1100]

--- a/src/gate_kernels.jl
+++ b/src/gate_kernels.jl
@@ -411,19 +411,7 @@ function apply_controlled_gate!(
     small_t = min(endian_control, endian_t1, endian_t2)
     big_t   = max(endian_control, endian_t1, endian_t2)
     # this big if/else is to avoid an allocation
-    mid_t   = if     small_t == endian_control && big_t == endian_t1
-                  endian_t2
-              elseif small_t == endian_control && big_t == endian_t2
-                  endian_t1
-              elseif small_t == endian_t1 && big_t == endian_t2
-                  endian_control
-              elseif small_t == endian_t2 && big_t == endian_t1
-                  endian_control
-              elseif small_t == endian_t1 && big_t == endian_control
-                  endian_t2
-              elseif small_t == endian_t2 && big_t == endian_control
-                  endian_t1
-              end
+    mid_t   = max(min(endian_control, endian_t1), min(endian_control, endian_t2), min(endian_t1, endian_t2))
     Threads.@threads for ix = 0:div(n_amps, 8)-1
         ix_00 = pad_bits(ix, (small_t, mid_t, big_t))
         if c_bit

--- a/src/raw_schema.jl
+++ b/src/raw_schema.jl
@@ -17,11 +17,7 @@ StructTypes.StructType(::Type{AbstractProgram}) = StructTypes.AbstractType()
 function bsh_f(raw_symbol::Symbol)
     raw = String(raw_symbol)
     v   = eval(Meta.parse(raw))
-    if v["name"] == "braket.ir.openqasm.program"
-        return OpenQasmProgram
-    else
-        return Program
-    end
+    return v["name"] == "braket.ir.openqasm.program" ? OpenQasmProgram : Program
 end
 StructTypes.subtypes(::Type{AbstractProgram}) = StructTypes.SubTypeClosure(bsh_f)
 StructTypes.subtypekey(::Type{AbstractProgram}) = :braketSchemaHeader
@@ -122,7 +118,6 @@ struct ResultTypeValue
     ResultTypeValue(type, value::Float64)             = new(type, value)
     ResultTypeValue(type, value::Dict{String, <:Any}) = new(type, value)
     ResultTypeValue(type, value::Vector)              = new(type, value)
-    ResultTypeValue(type, value::Union{Float64, Dict, Vector}) = new(type, value)
 end
 # for custom lowering of ComplexF64
 # just build the tuples directly to

--- a/src/result_types.jl
+++ b/src/result_types.jl
@@ -160,7 +160,7 @@ end
 
 function calculate(expectation_result::Expectation, sim::AbstractSimulator)
     obs             = expectation_result.observable
-    targets         = isempty(expectation_result.targets) ? collect(0:qubit_count(sim)-1) : expectation_result.targets
+    targets         = (isempty(expectation_result.targets) || isnothing(expectation_result.targets)) ? collect(0:qubit_count(sim)-1) : expectation_result.targets
     obs_qubit_count = qubit_count(obs)
     length(targets) == obs_qubit_count && return expectation(sim, obs, targets...)
     return [expectation(sim, obs, target) for target in targets]
@@ -222,7 +222,7 @@ apply_observable(observable::O, sv_or_dm, target::Int...) where {O<:Observables.
 
 function calculate(variance::Variance, sim::AbstractSimulator)
     obs     = variance.observable
-    targets = isnothing(variance.targets) ? collect(0:qubit_count(sim)-1) : variance.targets
+    targets = (isnothing(variance.targets) || isempty(variance.targets)) ? collect(0:qubit_count(sim)-1) : variance.targets
     obs_qubit_count = qubit_count(obs)
     if length(targets) == obs_qubit_count
         var2 = expectation_op_squared(sim, obs, targets...)
@@ -240,7 +240,7 @@ end
 function calculate(dm::DensityMatrix, sim::AbstractSimulator)
     ρ = density_matrix(sim)
     full_qubits = collect(0:qubit_count(sim)-1)
-    (collect(dm.targets) == full_qubits || isempty(dm.targets)) && return ρ
+    (collect(dm.targets) == full_qubits || isnothing(dm.targets) || isempty(dm.targets)) && return ρ
     length(dm.targets) == sim.qubit_count && return permute_density_matrix(ρ, sim.qubit_count, collect(dm.targets))
     # otherwise must compute a partial trace
     return partial_trace(ρ, dm.targets)

--- a/src/results.jl
+++ b/src/results.jl
@@ -38,6 +38,7 @@ for (typ, ir_typ, label) in ((:Expectation, :(IR.Expectation), "expectation"), (
               - Absent, in which case the observable `o` will be applied to all qubits provided it is a single qubit observable.
             """ $typ(o::Observables.Observable, targets) = new(o, QubitSet(targets))
         end
+        label(::$typ) = $label
         StructTypes.lower(x::$typ) = $ir_typ(StructTypes.lower(x.observable), (isempty(x.targets) ? nothing : Int.(x.targets)), $label)
     end
 end
@@ -69,6 +70,7 @@ for (typ, ir_typ, label) in ((:Probability, :(IR.Probability), "probability"), (
           - Absent, in which case the measurement will be applied to all qubits.
         """ $typ(targets) = $typ(QubitSet(targets))
         $typ(targets::Vararg{IntOrQubit}) = $typ(QubitSet(targets...))
+        label(::$typ) = $label
         StructTypes.lower(x::$typ) = $ir_typ(isempty(x.targets) ? nothing : Int.(x.targets), $label)
     end
 end
@@ -173,6 +175,7 @@ All elements of `states` must be `'0'` or `'1'`.
 """
 Amplitude(s::String) = Amplitude([s])
 Base.:(==)(a1::Amplitude, a2::Amplitude) = (a1.states == a2.states)
+label(::Amplitude) = "amplitude"
 
 """
     StateVector <: Result
@@ -181,10 +184,9 @@ Struct which represents a state vector measurement on a [`Circuit`](@ref).
 """
 struct StateVector <: Result end
 Base.:(==)(sv1::StateVector, sv2::StateVector) = true
+label(::StateVector) = "statevector"
 
 const ObservableResult = Union{Expectation, Variance, Sample}
 const ObservableParameterResult = Union{AdjointGradient,}
 StructTypes.lower(x::Amplitude) = IR.Amplitude(x.states, "amplitude")
 StructTypes.lower(x::StateVector) = IR.StateVector("statevector")
-
-ir(r::Result, ::Val{:JAQCD}; kwargs...) = StructTypes.lower(r)

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -25,7 +25,7 @@ end
 
 function _validate_ir_results_compatibility(
     simulator::D,
-    results::Vector{AbstractProgramResult},
+    results::Vector{<:AbstractProgramResult},
     supported_result_types::Vector,
 ) where {D<:AbstractSimulator}
     (isnothing(results) || isempty(results)) && return
@@ -39,7 +39,7 @@ function _validate_ir_results_compatibility(
 end
 function _validate_ir_results_compatibility(
     simulator::D,
-    results::Vector{Result},
+    results::Vector{<:Result},
     supported_result_types::Vector,
 ) where {D<:AbstractSimulator}
     (isnothing(results) || isempty(results)) && return

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -25,8 +25,8 @@ end
 
 function _validate_ir_results_compatibility(
     simulator::D,
-    results,
-    supported_result_types,
+    results::Vector{AbstractProgramResult},
+    supported_result_types::Vector,
 ) where {D<:AbstractSimulator}
     (isnothing(results) || isempty(results)) && return
     circuit_result_types_name    = [rt.type for rt in results]
@@ -37,25 +37,46 @@ function _validate_ir_results_compatibility(
     end
     return
 end
-_validate_ir_results_compatibility(simulator::D, results, ::Val{V}) where {D<:AbstractSimulator, V} = _validate_ir_results_compatibility(simulator, results, supported_result_types(simulator, Val(V)))
-
-function _validate_shots_and_ir_results(shots::Int, results, qubit_count::Int)
-    if shots == 0
-        (isnothing(results) || isempty(results)) && throw(ValidationError("Result types must be specified in the IR when shots=0", "ValueError"))
-        for rt in results
-            rt.type == "sample" && throw(ValidationError("sample can only be specified when shots>0", "ValueError"))
-            rt.type == "amplitude" && _validate_amplitude_states(rt.states, qubit_count)
-        end
-    elseif shots > 0 && !isnothing(results) && !isempty(results)
-        for rt in results
-            rt.type ∈ ["statevector", "amplitude", "densitymatrix"] && throw(ValidationError(
-                "statevector, amplitude and densitymatrix result types are only available when shots==0",
-                "ValueError"
-            ))
-        end
+function _validate_ir_results_compatibility(
+    simulator::D,
+    results::Vector{Result},
+    supported_result_types::Vector,
+) where {D<:AbstractSimulator}
+    (isnothing(results) || isempty(results)) && return
+    circuit_result_types_name    = map(label, results)
+    supported_result_types_names = map(supported_rt->lowercase(string(supported_rt.name)), supported_result_types)
+    for name in circuit_result_types_name
+        name ∉ supported_result_types_names &&
+            throw(ErrorException("result type $name not supported by $simulator"))
     end
     return
 end
+_validate_ir_results_compatibility(simulator::D, results::Vector{A}, ::Val{V}) where {D<:AbstractSimulator, A, V} = _validate_ir_results_compatibility(simulator, results, supported_result_types(simulator, Val(V)))
+
+_validate_exact_result(amp::Amplitude, qubit_count)    = _validate_amplitude_states(amp.states, qubit_count)
+_validate_exact_result(amp::IR.Amplitude, qubit_count) = _validate_amplitude_states(amp.states, qubit_count)
+_validate_exact_result(sample::Sample, qubit_count)    = throw(ValidationError("sample can only be specified when shots>0", "ValueError"))
+_validate_exact_result(sample::IR.Sample, qubit_count) = throw(ValidationError("sample can only be specified when shots>0", "ValueError"))
+_validate_exact_result(result, qubit_count)            = return
+
+const nonzero_shots_error = "statevector, amplitude and densitymatrix result types are only available when shots==0"
+_validate_nonzero_shots_result(sv::StateVector)      = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(sv::IR.StateVector)   = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(amp::Amplitude)       = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(amp::IR.Amplitude)    = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(dm::DensityMatrix)    = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(dm::IR.DensityMatrix) = throw(ValidationError(nonzero_shots_error, "ValueError"))
+_validate_nonzero_shots_result(result)               = return
+function _validate_shots_and_ir_results(shots::Int, results, qubit_count::Int)
+    if shots == 0
+        (isnothing(results) || isempty(results)) && throw(ValidationError("Result types must be specified in the IR when shots=0", "ValueError"))
+        foreach(r->_validate_exact_result(r, qubit_count), results)
+    elseif shots > 0 && !isnothing(results)
+        foreach(_validate_nonzero_shots_result, results)
+    end
+    return
+end
+
 function _validate_input_provided(circuit)
     for instruction in circuit.instructions
         possible_parameters = (Symbol("_angle"), Symbol("_angle_1"), Symbol("_angle_2"), Symbol("angle"))
@@ -74,10 +95,7 @@ function _validate_input_provided(circuit)
     return
 end
 
-function _validate_ir_instructions_compatibility(
-    circuit::Union{Program,Circuit},
-    supported_operations,
-)
+function _validate_ir_instructions_compatibility(circuit, supported_operations)
     circuit_instruction_names = map(ix->replace(lowercase(string(typeof(ix.operator))), "_"=>"", "braketsimulator."=>""), circuit.instructions)
     supported_instructions    = Set(map(op->replace(lowercase(op), "_"=>""), supported_operations))
     no_noise = true
@@ -90,7 +108,7 @@ function _validate_ir_instructions_compatibility(
     end
     return
 end
-_validate_ir_instructions_compatibility(simulator::D, circuit::Union{Program,Circuit}, v::Val{V}) where {D<:AbstractSimulator, V} = _validate_ir_instructions_compatibility(circuit, supported_operations(simulator, v))
+_validate_ir_instructions_compatibility(simulator::D, circuit, v::Val{V}) where {D<:AbstractSimulator, V} = _validate_ir_instructions_compatibility(circuit, supported_operations(simulator, v))
 
 _validate_result_type_qubits_exist(rt::StateVector, qubit_count::Int) = return
 _validate_result_type_qubits_exist(rt::Amplitude, qubit_count::Int)   = return

--- a/test/test_gate_operations.jl
+++ b/test/test_gate_operations.jl
@@ -51,6 +51,7 @@ using Test, LinearAlgebra, Logging, BraketSimulator, DataStructures
                                         BraketSimulator.CPhaseShift00(ϕ),
                                         BraketSimulator.CPhaseShift01(ϕ),
                                         BraketSimulator.CPhaseShift10(ϕ),
+                                        BraketSimulator.SingleExcitation(ϕ),
                                         BraketSimulator.Unitary(q2_mat),
                                         BraketSimulator.CNot(),
                                         BraketSimulator.CY(),
@@ -124,6 +125,7 @@ using Test, LinearAlgebra, Logging, BraketSimulator, DataStructures
                                         BraketSimulator.CPhaseShift00(ϕ),
                                         BraketSimulator.CPhaseShift01(ϕ),
                                         BraketSimulator.CPhaseShift10(ϕ),
+                                        BraketSimulator.SingleExcitation(ϕ),
                                         BraketSimulator.Unitary(q2_mat),
                                         BraketSimulator.Control(BraketSimulator.MultiQubitPhaseShift{2}(ϕ), (0,0)),
                                         BraketSimulator.MultiQubitPhaseShift{2}(ϕ),]
@@ -162,6 +164,19 @@ using Test, LinearAlgebra, Logging, BraketSimulator, DataStructures
                 @test BraketSimulator.matrix_rep(g)^pow ≈ BraketSimulator.matrix_rep(g^pow)
             end
             sim = BraketSimulator.evolve!(sim, instructions)
+            new_sim = BraketSimulator.evolve!(new_sim, new_instructions)
+            @test new_sim.state_vector ≈ sim.state_vector
+        end
+        @testset "4q Gate $g" for g in [BraketSimulator.DoubleExcitation(ϕ),]
+            nq  = 5
+            sim = StateVectorSimulator(nq, 0)
+            new_sim = StateVectorSimulator(nq, 0)
+            instructions     = vcat([BraketSimulator.Instruction(BraketSimulator.H(), [q]) for q in 0:nq-1], [BraketSimulator.Instruction(g^pow, [0, 1, 3, 2])])
+            new_instructions = vcat([BraketSimulator.Instruction(BraketSimulator.H(), [q]) for q in 0:nq-1], [BraketSimulator.Instruction(BraketSimulator.Unitary(Matrix(BraketSimulator.matrix_rep(g)))^pow, [0, 1, 3, 2])])
+            if !isa(g^pow, BraketSimulator.I)
+                @test BraketSimulator.matrix_rep(g)^pow ≈ BraketSimulator.matrix_rep(g^pow)
+            end
+            sim     = BraketSimulator.evolve!(sim, instructions)
             new_sim = BraketSimulator.evolve!(new_sim, new_instructions)
             @test new_sim.state_vector ≈ sim.state_vector
         end

--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -213,6 +213,23 @@ get_tol(shots::Int) = return (
                                        BraketSimulator.Instruction(BraketSimulator.Measure(), 1)]
         @test [qubit_count(ix.operator) for ix in circuit.instructions] == [1, 1]
     end
+    @testset "Measure with density matrix" begin
+        qasm = """
+        qubit[3] qs;
+        qubit q;
+
+        x qs[{0, 2}];
+        h q;
+        cphaseshift(1) qs, q;
+        phaseshift(-2) q;
+        measure qs;
+        measure q;
+        """
+        circuit    = BraketSimulator.Circuit(qasm)
+        simulation = BraketSimulator.DensityMatrixSimulator(4, 0)
+        BraketSimulator.evolve!(simulation, circuit.instructions)
+        @test BraketSimulator.probabilities(simulation) ≈ (1/2)*[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]
+    end
     @testset "GPhase" begin
         qasm = """
         qubit[2] qs;
@@ -1284,8 +1301,6 @@ get_tol(shots::Int) = return (
         """
         circuit        = BraketSimulator.Circuit(with_verbatim)
         sim_w_verbatim = BraketSimulator.StateVectorSimulator(2, 0)
-        pop!(circuit.instructions) 
-        pop!(circuit.instructions) 
         BraketSimulator.evolve!(sim_w_verbatim, circuit.instructions)
 
         without_verbatim = """
@@ -1302,8 +1317,6 @@ get_tol(shots::Int) = return (
         """
         circuit         = BraketSimulator.Circuit(without_verbatim)
         sim_wo_verbatim = BraketSimulator.StateVectorSimulator(2, 0)
-        pop!(circuit.instructions) 
-        pop!(circuit.instructions) 
         BraketSimulator.evolve!(sim_wo_verbatim, circuit.instructions)
 
         @test sim_w_verbatim.state_vector ≈ sim_wo_verbatim.state_vector

--- a/test/test_python_ext.jl
+++ b/test/test_python_ext.jl
@@ -67,42 +67,50 @@ using Test, JSON3, PythonCall, BraketSimulator
                 cnot \$0, \$1;
                 #pragma braket result state_vector
                 """
-                oq3_results  = BraketSimulator.simulate("braket_sv_v2", PyList([simple_bell_qasm]), "[{}]", 0)
-                for oq3_result in oq3_results
-                    result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
-                    @test result.additionalMetadata.action.source == simple_bell_qasm
-                    @test length(result.resultTypes) == 1
-                    @test result.resultTypes[1].type == BraketSimulator.IR.StateVector("statevector")
-                end
+                oq3_result  = BraketSimulator.simulate("braket_sv_v2", simple_bell_qasm, "{}", 0)
+                result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
+                @test result.additionalMetadata.action.source == simple_bell_qasm
+                @test length(result.resultTypes) == 1
+                @test result.resultTypes[1].type == BraketSimulator.IR.StateVector("statevector")
+
                 simple_bell_qasm = """
                 h \$0;
                 cy \$0, \$1;
                 #pragma braket result amplitude '00', '01', '10', '11' 
                 """
-                oq3_results  = BraketSimulator.simulate("braket_sv_v2", PyList([simple_bell_qasm]), "[{}]", 0)
-                for oq3_result in oq3_results
-                    result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
-                    @test result.additionalMetadata.action.source == simple_bell_qasm
-                    @test length(result.resultTypes) == 1
-                    @test result.resultTypes[1].type.type == "amplitude"
-                    @test result.resultTypes[1].type.states == ["00", "01", "10", "11"]
-                    @test result.resultTypes[1].value == Dict("00"=>[1/√2, 0.0], "01"=>[0.0, 0.0], "10"=>[0.0, 0.0], "11"=>[0.0, 1/√2])
-                end
+                oq3_result  = BraketSimulator.simulate("braket_sv_v2", simple_bell_qasm, "{}", 0)
+                result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
+                @test result.additionalMetadata.action.source == simple_bell_qasm
+                @test length(result.resultTypes) == 1
+                @test result.resultTypes[1].type.type == "amplitude"
+                @test result.resultTypes[1].type.states == ["00", "01", "10", "11"]
+                @test result.resultTypes[1].value == Dict("00"=>[1/√2, 0.0], "01"=>[0.0, 0.0], "10"=>[0.0, 0.0], "11"=>[0.0, 1/√2])
+
                 simple_bell_qasm = """
                 h \$0;
                 cy \$0, \$1;
                 #pragma braket result expectation z(\$0)
                 """
-                oq3_results  = BraketSimulator.simulate("braket_sv_v2", PyList([simple_bell_qasm]), "[{}]", 0)
-                for oq3_result in oq3_results
-                    result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
-                    @test result.additionalMetadata.action.source == simple_bell_qasm
-                    @test length(result.resultTypes) == 1
-                    @test result.resultTypes[1].type.type    == "expectation"
-                    @test result.resultTypes[1].type.targets == [0] 
-                    @test result.resultTypes[1].type.observable == ["z"]
-                    @test result.resultTypes[1].value == 0.0
-                end
+                oq3_result  = BraketSimulator.simulate("braket_sv_v2", simple_bell_qasm, "{}", 0)
+                result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
+                @test result.additionalMetadata.action.source == simple_bell_qasm
+                @test length(result.resultTypes) == 1
+                @test result.resultTypes[1].type.type    == "expectation"
+                @test result.resultTypes[1].type.targets == [0] 
+                @test result.resultTypes[1].type.observable == ["z"]
+                @test result.resultTypes[1].value == 0.0
+
+                simple_bell_qasm = """
+                h \$0;
+                cy \$0, \$1;
+                #pragma braket result density_matrix
+                """
+                oq3_result  = BraketSimulator.simulate("braket_dm_v2", simple_bell_qasm, "{}", 0)
+                result = JSON3.read(oq3_result, BraketSimulator.GateModelTaskResult)
+                @test result.additionalMetadata.action.source == simple_bell_qasm
+                @test length(result.resultTypes) == 1
+                @test result.resultTypes[1].type.type    == "densitymatrix"
+                @test result.resultTypes[1].type.targets == nothing
             end
         end
     end

--- a/test/test_result_types.jl
+++ b/test/test_result_types.jl
@@ -226,4 +226,18 @@ all_qubit_observables_testdata = [
             @test all(s->s ∈ [0, 2^30-1], shot_results)
         end
     end
+    @testset "Result type $rt translation" for (rt, ir_rt) in ((BraketSimulator.StateVector(), BraketSimulator.IR.StateVector("statevector")),
+                                                               (BraketSimulator.DensityMatrix([0, 1]), BraketSimulator.IR.DensityMatrix([0, 1], "densitymatrix")),
+                                                               (BraketSimulator.Probability([0, 1]), BraketSimulator.IR.Probability([0, 1], "probability")),
+                                                               (BraketSimulator.Amplitude(["01", "10"]), BraketSimulator.IR.Amplitude(["01", "10"], "amplitude")),
+                                                              )
+        @test BraketSimulator._translate_result_type(ir_rt) == rt
+    end
+    @testset "Result type $rt translation" for (rt, ir_rt) in ((BraketSimulator.Expectation(BraketSimulator.Observables.TensorProduct(["z", "x"]), [1, 0]), BraketSimulator.IR.Expectation(["z", "x"], [1, 0], "expectation")),
+                                                               (BraketSimulator.Variance(BraketSimulator.Observables.TensorProduct(["z", "x"]), [1, 0]), BraketSimulator.IR.Variance(["z", "x"], [1, 0], "variance")),
+                                                               (BraketSimulator.Sample(BraketSimulator.Observables.TensorProduct(["z", "x"]), [1, 0]), BraketSimulator.IR.Sample(["z", "x"], [1, 0], "sample")),
+                                                              )
+        @test BraketSimulator._translate_result_type(ir_rt).observable == rt.observable
+        @test BraketSimulator._translate_result_type(ir_rt).targets    == rt.targets
+    end
 end

--- a/test/test_sv_simulator.jl
+++ b/test/test_sv_simulator.jl
@@ -218,6 +218,56 @@ LARGE_TESTS = get(ENV, "BRAKET_SIM_LARGE_TESTS", "false") == "true"
             [0, 0, 0, 0, 0, 1, 0, 0],
             [0, 0, 0, 0, 0, 1, 0, 0],
         ),
+        (
+            [
+                BraketSimulator.Instruction(BraketSimulator.X(), [0]),
+                BraketSimulator.Instruction(BraketSimulator.X(), [2]),
+                BraketSimulator.Instruction(BraketSimulator.CSwap(), [0, 2, 1]),
+            ],
+            3,
+            [0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+        ),
+        (
+            [
+                BraketSimulator.Instruction(BraketSimulator.X(), [1]),
+                BraketSimulator.Instruction(BraketSimulator.X(), [2]),
+                BraketSimulator.Instruction(BraketSimulator.CSwap(), [1, 2, 0]),
+            ],
+            3,
+            [0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 0, 0, 0, 1, 0],
+        ),
+        (
+            [
+                BraketSimulator.Instruction(BraketSimulator.X(), [1]),
+                BraketSimulator.Instruction(BraketSimulator.X(), [2]),
+                BraketSimulator.Instruction(BraketSimulator.CSwap(), [2, 1, 0]),
+            ],
+            3,
+            [0, 0, 0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0, 0],
+        ),
+        (
+            [
+                BraketSimulator.Instruction(BraketSimulator.X(), [0]),
+                BraketSimulator.Instruction(BraketSimulator.X(), [2]),
+                BraketSimulator.Instruction(BraketSimulator.CSwap(), [2, 0, 1]),
+            ],
+            3,
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+        ),
+        (
+            [
+                BraketSimulator.Instruction(BraketSimulator.X(), [0]),
+                BraketSimulator.Instruction(BraketSimulator.X(), [1]),
+                BraketSimulator.Instruction(BraketSimulator.CSwap(), [1, 0, 2]),
+            ],
+            3,
+            [0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0, 0, 0],
+        ),
     ]
         @testset "Simulator $sim" for sim in (StateVectorSimulator, DensityMatrixSimulator) 
             simulation = sim(qubit_count, 0)

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -17,7 +17,23 @@ using Test, BraketSimulator
     BraketSimulator.add_instruction!(c, BraketSimulator.Instruction(BraketSimulator.Rx(0.1), 0))
     @test isnothing(BraketSimulator._validate_input_provided(c))
 
-    
+
+    @testset for rt in (BraketSimulator.StateVector(),
+                        BraketSimulator.IR.StateVector("statevector"),
+                        BraketSimulator.Amplitude(["00", "11"]),
+                        BraketSimulator.IR.Amplitude(["00", "11"], "amplitude"),
+                        BraketSimulator.DensityMatrix(),
+                        BraketSimulator.IR.DensityMatrix(nothing, "densitymatrix")
+                       )
+        @test_throws BraketSimulator.ValidationError("statevector, amplitude and densitymatrix result types are only available when shots==0", "ValueError") BraketSimulator._validate_shots_and_ir_results(1, [rt], 1)
+    end
+    @testset for rt in (BraketSimulator.Sample(BraketSimulator.Observables.Z(), 0),
+                        BraketSimulator.IR.Sample("z", [0], "sample"),
+                       )
+        @test_throws BraketSimulator.ValidationError("sample can only be specified when shots>0", "ValueError") BraketSimulator._validate_shots_and_ir_results(0, [rt], 1)
+    end
+
+
     sim = DensityMatrixSimulator(2, 0)
     @test_logs (:warn, "You are running a noise-free circuit on the density matrix simulator. Consider running this circuit on the state vector simulator: LocalSimulator(\"braket_sv_v2\") for a better user experience.") BraketSimulator._validate_ir_instructions_compatibility(sim, c, Val(:OpenQASM))
     @test_logs (:warn, "You are running a noise-free circuit on the density matrix simulator. Consider running this circuit on the state vector simulator: LocalSimulator(\"braket_sv_v2\") for a better user experience.") BraketSimulator._validate_ir_instructions_compatibility(sim, c, Val(:JAQCD))

--- a/test/test_validation.jl
+++ b/test/test_validation.jl
@@ -2,9 +2,14 @@ using Test, BraketSimulator
 
 @testset "IR validation" begin
     sim = DensityMatrixSimulator(2, 0)
-    results = [(type="NotARealResult",)]
-    @test_throws ErrorException BraketSimulator._validate_ir_results_compatibility(sim, results, Val(:OpenQASM))
-    @test_throws ErrorException BraketSimulator._validate_ir_results_compatibility(sim, results, Val(:JAQCD))
+    struct NotARealResult <: BraketSimulator.Result end
+    BraketSimulator.label(::NotARealResult) = "notarealresult"
+    @test_throws ErrorException BraketSimulator._validate_ir_results_compatibility(sim, [NotARealResult()], Val(:OpenQASM))
+    struct NotARealIRResult <: BraketSimulator.AbstractProgramResult
+        type::String
+        NotARealIRResult() = new("notarealresult")
+    end
+    @test_throws ErrorException BraketSimulator._validate_ir_results_compatibility(sim, [NotARealIRResult()], Val(:JAQCD))
     c = BraketSimulator.Circuit()
     BraketSimulator.add_instruction!(c, BraketSimulator.Instruction(BraketSimulator.Rx(BraketSimulator.FreeParameter(:α)), 0))
     @test_throws ErrorException BraketSimulator._validate_input_provided(c)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Makes writing to JSON substantially faster for big statevectors/density matrices. Cleaned up a lot of internal allocations in the gate kernels. Benchmarked **from Python** and seeing speedups now comparable to what we see from Julia.

*Testing done:* Unit tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
