### PR TITLE
fix: Memory frugal density matrix computation for state vectors

### DIFF
--- a/src/dm_simulator.jl
+++ b/src/dm_simulator.jl
@@ -318,3 +318,4 @@ function partial_trace(
     end
     return final_ρ
 end
+partial_trace(sim::DensityMatrixSimulator, output_qubits = collect(0:qubit_count(sim)-1)) = partial_trace(density_matrix(sim), output_qubits)

--- a/src/result_types.jl
+++ b/src/result_types.jl
@@ -238,10 +238,9 @@ function calculate(variance::Variance, sim::AbstractSimulator)
 end
 
 function calculate(dm::DensityMatrix, sim::AbstractSimulator)
-    ρ = density_matrix(sim)
     full_qubits = collect(0:qubit_count(sim)-1)
-    (collect(dm.targets) == full_qubits || isnothing(dm.targets) || isempty(dm.targets)) && return ρ
-    length(dm.targets) == sim.qubit_count && return permute_density_matrix(ρ, sim.qubit_count, collect(dm.targets))
+    (collect(dm.targets) == full_qubits || isnothing(dm.targets) || isempty(dm.targets)) && return density_matrix(sim)
+    length(dm.targets) == sim.qubit_count && return permute_density_matrix(density_matrix(sim), sim.qubit_count, collect(dm.targets))
     # otherwise must compute a partial trace
-    return partial_trace(ρ, dm.targets)
+    return partial_trace(sim, dm.targets)
 end

--- a/test/test_sv_simulator.jl
+++ b/test/test_sv_simulator.jl
@@ -1,4 +1,4 @@
-using Test, BraketSimulator, DataStructures
+using Test, BraketSimulator, DataStructures, LinearAlgebra, BraketSimulator.Combinatorics
 
 LARGE_TESTS = get(ENV, "BRAKET_SIM_LARGE_TESTS", "false") == "true"
 
@@ -707,6 +707,15 @@ LARGE_TESTS = get(ENV, "BRAKET_SIM_LARGE_TESTS", "false") == "true"
         new_sv_props = BraketSimulator.StructTypes.constructfrom(BraketSimulator.GateModelSimulatorDeviceCapabilities, new_sv_props_dict)
         @test new_sv_props.paradigm.qubitCount == new_sv_qubit_count
         @test BraketSimulator.supported_result_types(sim) == BraketSimulator.supported_result_types(sim, Val(:OpenQASM))
+    end
+    @testset "partial trace $nq" for nq in 3:6
+        ψ       = normalize(rand(ComplexF64, 2^nq))
+        full_ρ  = kron(ψ, adjoint(ψ))
+        @testset "output qubits $q" for q in combinations(0:nq-1)
+            ρ       = BraketSimulator.partial_trace(ψ, q)
+            full_pt = BraketSimulator.partial_trace(full_ρ, q)
+            @test full_pt ≈ ρ
+        end
     end
     @testset "inputs handling" begin
         sv_adder_qasm = """


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Avoid constructing the entire density matrix for `StateVectorSimulator`s if we don't have to, as this can be super memory intensive.

*Testing done:* Added unit tests which passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
