### PR TITLE
feature: Add parsing support for barrier/reset/delay/duration

### DIFF
--- a/docs/src/circuits.md
+++ b/docs/src/circuits.md
@@ -12,6 +12,9 @@ BraketSimulator.Circuit
 BraketSimulator.Operator
 BraketSimulator.QuantumOperator
 BraketSimulator.FreeParameter
+BraketSimulator.Reset
+BraketSimulator.Barrier
+BraketSimulator.Delay
 BraketSimulator.Measure
 BraketSimulator.Instruction
 BraketSimulator.QubitSet

--- a/src/dm_simulator.jl
+++ b/src/dm_simulator.jl
@@ -148,11 +148,15 @@ function _evolve_op!(
 ) where {T<:Complex,S<:AbstractDensityMatrix{T},N<:Noise}
     apply_noise!(op, dms.density_matrix, target...)
 end
-# Measure operators are no-ops for now as measurement is handled at the end
-# of simulation, in the results computation step. If/when mid-circuit
-# measurement is supported, this operation will collapse the density
-# matrix on the measured qubits.
+# Measure, barrier, reset, and delay operators are no-ops for now as
+# measurement is handled at the end of simulation, in the results
+# computation step. If/when mid-circuit # measurement is supported,
+# this operation will collapse the density # matrix on the measured qubits.
+# Barrier, reset, and delay are also to-do implementations.
 _evolve_op!(dms::DensityMatrixSimulator{T,S}, m::Measure, args...) where {T<:Complex,S<:AbstractDensityMatrix{T}} = return
+_evolve_op!(dms::DensityMatrixSimulator{T,S}, b::Barrier, args...) where {T<:Complex,S<:AbstractDensityMatrix{T}} = return
+_evolve_op!(dms::DensityMatrixSimulator{T,S}, r::Reset, args...) where {T<:Complex,S<:AbstractDensityMatrix{T}} = return
+_evolve_op!(dms::DensityMatrixSimulator{T,S}, d::Delay, args...) where {T<:Complex,S<:AbstractDensityMatrix{T}} = return
 
 """
     evolve!(dms::DensityMatrixSimulator{T, S<:AbstractMatrix{T}}, operations::Vector{Instruction}) -> DensityMatrixSimulator{T, S}

--- a/src/gate_kernels.jl
+++ b/src/gate_kernels.jl
@@ -282,6 +282,9 @@ apply_gate!(::Val{false}, g::I, state_vec::AbstractStateVector{T}, qubits::Int..
 apply_gate!(::Val{true}, g::I, state_vec::AbstractStateVector{T}, qubits::Int...) where {T<:Complex} =
     return
 apply_gate!(::Measure, state_vec, args...) = return
+apply_gate!(::Reset, state_vec, args...) = return
+apply_gate!(::Barrier, state_vec, args...) = return
+apply_gate!(::Delay, state_vec, args...) = return
 
 function apply_gate!(
     g_matrix::Union{SMatrix{2,2,T}, Diagonal{T,SVector{2,T}}},

--- a/src/gates.jl
+++ b/src/gates.jl
@@ -116,8 +116,6 @@ Parametrizable(g::AngledGate) = Parametrized()
 Parametrizable(g::Gate)       = NonParametrized()
 parameters(g::AngledGate)     = collect(filter(a->a isa FreeParameter, angles(g)))
 parameters(g::Gate)           = FreeParameter[] 
-bind_value!(g::G, params::Dict{Symbol, <:Real}) where {G<:Gate} = bind_value!(Parametrizable(g), g, params)
-bind_value!(::NonParametrized, g::G, params::Dict{Symbol, <:Real}) where {G<:Gate} = g
 # nosemgrep
 function bind_value!(::Parametrized, g::G, params::Dict{Symbol, <:Real}) where {G<:AngledGate}
     new_angles = map(angles(g)) do angle

--- a/src/gates.jl
+++ b/src/gates.jl
@@ -115,7 +115,6 @@ qubit_count(g::Unitary) = convert(Int, log2(size(g.matrix, 1)))
 Parametrizable(g::AngledGate) = Parametrized()
 Parametrizable(g::Gate)       = NonParametrized()
 parameters(g::AngledGate)     = collect(filter(a->a isa FreeParameter, angles(g)))
-parameters(g::Gate)           = FreeParameter[] 
 # nosemgrep
 function bind_value!(::Parametrized, g::G, params::Dict{Symbol, <:Real}) where {G<:AngledGate}
     new_angles = map(angles(g)) do angle

--- a/src/noises.jl
+++ b/src/noises.jl
@@ -141,7 +141,7 @@ end
 Base.:(==)(c1::MultiQubitPauliChannel{N}, c2::MultiQubitPauliChannel{M}) where {N,M} = N == M && c1.probabilities == c2.probabilities
 
 Parametrizable(g::Noise) = NonParametrized()
-parameters(g::Noise) = parameters(Parametrizable(g), g)
+parameters(g::Noise)     = parameters(Parametrizable(g), g)
 parameters(::Parametrized, g::N) where {N<:Noise} = filter(x->x isa FreeParameter, [getproperty(g, fn) for fn in fieldnames(N)])
 parameters(::NonParametrized, g::Noise) = FreeParameter[]
 

--- a/src/noises.jl
+++ b/src/noises.jl
@@ -144,8 +144,6 @@ Parametrizable(g::Noise) = NonParametrized()
 parameters(g::Noise) = parameters(Parametrizable(g), g)
 parameters(::Parametrized, g::N) where {N<:Noise} = filter(x->x isa FreeParameter, [getproperty(g, fn) for fn in fieldnames(N)])
 parameters(::NonParametrized, g::Noise) = FreeParameter[]
-bind_value!(n::N, params::Dict{Symbol, <:Real}) where {N<:Noise} = bind_value!(Parametrizable(n), n, params)
-bind_value!(::NonParametrized, n::N, params::Dict{Symbol, <:Real}) where {N<:Noise} = n
 
 # nosemgrep
 function bind_value!(::Parametrized, g::N, params::Dict{Symbol, <:Real}) where {N<:Noise}

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -54,6 +54,8 @@ function Base.getindex(p::PauliEigenvalues{N}, i::Int)::Float64 where N
 end
 Base.getindex(p::PauliEigenvalues{N}, ix::Vector{Int}) where {N} = [p[i] for i in ix]
 
+parameters(o::QuantumOperator) = FreeParameter[] 
+
 """
     Measure(index) <: QuantumOperator
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -66,3 +66,47 @@ Measure() = Measure(-1)
 Parametrizable(m::Measure) = NonParametrized()
 qubit_count(::Type{Measure}) = 1
 qubit_count(m::Measure) = qubit_count(Measure)
+
+"""
+    Reset(index) <: QuantumOperator
+
+Represents an active reset operation on targeted qubit, stored in the classical register at `index`.
+For now, this is a no-op.
+"""
+struct Reset <: QuantumOperator
+    index::Int
+end
+Reset() = Reset(-1)
+Parametrizable(m::Reset) = NonParametrized()
+qubit_count(::Type{Reset}) = 1
+qubit_count(m::Reset) = qubit_count(Reset)
+
+"""
+    Barrier(index) <: QuantumOperator
+
+Represents a barrier operation on targeted qubit, stored in the classical register at `index`.
+For now, this is a no-op.
+"""
+struct Barrier <: QuantumOperator
+    index::Int
+end
+Barrier() = Barrier(-1)
+Parametrizable(m::Barrier) = NonParametrized()
+qubit_count(::Type{Barrier}) = 1
+qubit_count(m::Barrier) = qubit_count(Barrier)
+
+"""
+    Delay(index, duration::Time) <: QuantumOperator
+
+Represents a delay operation for `duration` on targeted qubit,
+stored in the classical register at `index`.
+For now, this is a no-op.
+"""
+struct Delay <: QuantumOperator
+    index::Int
+    duration::Dates.Period
+end
+Delay(duration::Dates.Period) = Delay(-1, duration)
+Parametrizable(m::Delay) = NonParametrized()
+qubit_count(::Type{Delay}) = 1
+qubit_count(m::Delay) = qubit_count(Delay)

--- a/src/schemas.jl
+++ b/src/schemas.jl
@@ -22,4 +22,6 @@ end
 Instruction(o::O, target) where {O<:Operator} = Instruction{O}(o, QubitSet(target...))
 Base.:(==)(ix1::Instruction{O}, ix2::Instruction{O}) where {O<:Operator} = (ix1.operator == ix2.operator && ix1.target == ix2.target)
 bind_value!(ix::Instruction{O}, param_values::Dict{Symbol, <:Real}) where {O<:Operator} = Instruction{O}(bind_value!(ix.operator, param_values), ix.target)
+bind_value!(o::O, params::Dict{Symbol, <:Real}) where {O<:Operator} = bind_value!(Parametrizable(o), o, params)
+bind_value!(::NonParametrized, o::O, params::Dict{Symbol, <:Real}) where {O<:Operator} = o
 remap(@nospecialize(ix::Instruction{O}), mapping::Dict{<:Integer, <:Integer}) where {O} = Instruction{O}(copy(ix.operator), [mapping[q] for q in ix.target])

--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -1,4 +1,4 @@
-using BraketSimulator.Quasar, Statistics, LinearAlgebra, BraketSimulator, BraketSimulator.Observables
+using BraketSimulator.Quasar, BraketSimulator.Dates, Statistics, LinearAlgebra, BraketSimulator, BraketSimulator.Observables
 
 get_tol(shots::Int) = return (
     shots > 0 ? Dict("atol" => 0.1, "rtol" => 0.15) : Dict("atol" => 0.01, "rtol" => 0)
@@ -560,9 +560,10 @@ get_tol(shots::Int) = return (
     @testset "Delay" begin
         qasm = """
         qubit[4] q;
-        delay[200dt] q[0], q[1];
+        delay[200us] q[0], q[1];
         """
         @test_warn "delay expression encountered -- currently `delay` is a no-op" parse_qasm(qasm)
+        @test BraketSimulator.Circuit(qasm).instructions == [BraketSimulator.Instruction(BraketSimulator.Delay(Microsecond(200)), 0), BraketSimulator.Instruction(BraketSimulator.Delay(Microsecond(200)), 1)]
     end
     @testset "Barrier" begin
         qasm = """
@@ -571,6 +572,7 @@ get_tol(shots::Int) = return (
         barrier q[0];
         """
         @test_warn "barrier expression encountered -- currently `barrier` is a no-op" parse_qasm(qasm)
+        @test BraketSimulator.Circuit(qasm).instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0), BraketSimulator.Instruction(BraketSimulator.Barrier(), 0)]
     end
     @testset "Stretch" begin
         qasm = """
@@ -591,6 +593,7 @@ get_tol(shots::Int) = return (
         reset q[0];
         """
         @test_warn "reset expression encountered -- currently `reset` is a no-op" parse_qasm(qasm)
+        @test BraketSimulator.Circuit(qasm).instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0), BraketSimulator.Instruction(BraketSimulator.Reset(), 0)]
     end
     @testset "Gate call missing/extra args" begin
         qasm = """

--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -557,6 +557,13 @@ get_tol(shots::Int) = return (
         """
         @test_throws Quasar.QasmParseError parse_qasm(qasm)
     end
+    @testset "Delay" begin
+        qasm = """
+        qubit[4] q;
+        delay[200dt] q[0], q[1];
+        """
+        @test_warn "delay expression encountered -- currently `delay` is a no-op" parse_qasm(qasm)
+    end
     @testset "Barrier" begin
         qasm = """
         qubit[4] q;

--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -558,7 +558,9 @@ get_tol(shots::Int) = return (
         @test_throws Quasar.QasmParseError parse_qasm(qasm)
     end
     @testset "Delay $duration" for (duration, ix) in (("200us", Microsecond(200)),
+                                                      ("100μs", Microsecond(100)),
                                                       ("50ns", Nanosecond(50)),
+                                                      ("20dt", Nanosecond(20)),
                                                       ("10ms", Millisecond(10)),
                                                       ("1s", Second(1)),
                                                      )
@@ -570,7 +572,7 @@ get_tol(shots::Int) = return (
         delay[$duration] q[0], q[1];
         """
         @test_warn "delay expression encountered -- currently `delay` is a no-op" parse_qasm(qasm)
-        circuit = BraketSimulator.Circuit(qasm)
+        circuit = Quasar.to_circuit(qasm)
         @test circuit.instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0),
                                        BraketSimulator.Instruction(BraketSimulator.Delay(ix), 0),
                                        BraketSimulator.Instruction(BraketSimulator.Delay(ix), 1),
@@ -594,7 +596,7 @@ get_tol(shots::Int) = return (
         #pragma braket result state_vector
         """
         @test_warn "barrier expression encountered -- currently `barrier` is a no-op" parse_qasm(qasm)
-        circuit = BraketSimulator.Circuit(qasm)
+        circuit = Quasar.to_circuit(qasm)
         @test circuit.instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0), BraketSimulator.Instruction(BraketSimulator.Barrier(), 0)]
         simulation = BraketSimulator.StateVectorSimulator(4, 0)
         ref_circ   = BraketSimulator.Circuit()
@@ -626,7 +628,7 @@ get_tol(shots::Int) = return (
         reset q[0];
         """
         @test_warn "reset expression encountered -- currently `reset` is a no-op" parse_qasm(qasm)
-        circuit = BraketSimulator.Circuit(qasm)
+        circuit = Quasar.to_circuit(qasm)
         @test circuit.instructions == [BraketSimulator.Instruction(BraketSimulator.X(), 0), BraketSimulator.Instruction(BraketSimulator.Reset(), 0)]
         simulation = BraketSimulator.StateVectorSimulator(4, 0)
         ref_circ   = BraketSimulator.Circuit()

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -1,0 +1,12 @@
+using BraketSimulator, BraketSimulator.Dates, Test
+
+@testset "Operators" begin
+    for op in (BraketSimulator.Measure(),
+               BraketSimulator.Reset(),
+               BraketSimulator.Barrier(),
+               BraketSimulator.Delay(Microsecond(200))
+              )
+        @test BraketSimulator.qubit_count(op) == 1
+        @test BraketSimulator.parameters(op)  == BraketSimulator.FreeParameter[]
+    end
+end


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Allows parsing of QASM files that use `reset`, `barrier`, `delay` and `duration` instructions. Currently these don't actually apply the reset or barrier (they are no-ops) but this would allow proper implementation of these operations.

*Testing done:* Unit tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
