### PR TITLE
fix: Allow reset after measurement

### DIFF
--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -725,6 +725,24 @@ get_tol(shots::Int) = return (
         BraketSimulator.evolve!(simulation, circuit.instructions)
         BraketSimulator.evolve!(ref_sim, ref_circ.instructions)
         @test simulation.state_vector ≈ ref_sim.state_vector
+        @testset "Reset after Measure" begin
+            good_qasm = """
+            qubit[4] q;
+            measure q[0];
+            reset q[0];
+            x q[0];
+            """
+            circuit = BraketSimulator.to_circuit(good_qasm) # no error
+            @test circuit.instructions == [BraketSimulator.Instruction(BraketSimulator.Measure(), 0), BraketSimulator.Instruction(BraketSimulator.Reset(), 0), BraketSimulator.Instruction(BraketSimulator.X(), 0)]
+            bad_qasm = """
+            qubit[4] q;
+            measure q[0];
+            reset q[0];
+            measure q[0];
+            x q[0];
+            """
+            @test_throws ErrorException("cannot apply instruction to measured qubits.") BraketSimulator.to_circuit(bad_qasm)
+        end
     end
     @testset "Gate call missing/extra args" begin
         qasm = """


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amazon-braket/BraketSimulator.jl/issues/45

*Description of changes:* Allow `Reset` after `Measure` to support mid circuit measurement.

*Testing done:* Unit tests passed locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
