### PR TITLE
fix: Improvements to precompilation and adjustments to new Quasar api

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BraketSimulator"
 uuid = "76d27892-9a0b-406c-98e4-7c178e9b3dff"
 authors = ["Katharine Hyatt <hyatkath@amazon.com> and contributors"]
-version = "0.0.6"
+version = "0.0.7"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -39,7 +39,7 @@ Logging = "1.6"
 OrderedCollections = "=1.6.3"
 PrecompileTools = "=1.2.1"
 PythonCall = "=0.9.23"
-Quasar = "0.0.1"
+Quasar = "0.0.2"
 Random = "1.6"
 StaticArrays = "1.9"
 StatsBase = "0.34"

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -82,7 +82,7 @@ function __init__()
     Quasar.visit_pragma[]  = visit_pragma
 end
 
-const LOG2_CHUNK_SIZE = 10
+const LOG2_CHUNK_SIZE = 16
 const CHUNK_SIZE      = 2^LOG2_CHUNK_SIZE
 
 function _index_to_endian_bits(ix::Int, qubit_count::Int)
@@ -205,7 +205,7 @@ basis rotation instructions if running with non-zero shots. Return the `Program`
 parsing and the qubit count of the circuit.
 """
 function _prepare_program(circuit_ir::OpenQasmProgram, inputs::Dict{String, <:Any}, shots::Int)
-    ir_inputs = isnothing(circuit_ir.inputs) ? Dict{String, Float64}() : circuit_ir.inputs 
+    ir_inputs     = isnothing(circuit_ir.inputs) ? Dict{String, Float64}() : circuit_ir.inputs
     merged_inputs = merge(ir_inputs, inputs)
     src           = circuit_ir.source::String
     circuit       = to_circuit(src, merged_inputs)
@@ -706,11 +706,14 @@ include("dm_simulator.jl")
         bit[3] b;
         qubit[3] q;
         rx(0.1) q[0];
+        rx(1) q[0];
         prx(0.1, 0.2) q[0];
         x q[0];
         ry(0.1) q[0];
+        ry(1) q[0];
         y q[0];
         rz(0.1) q[0];
+        rz(1) q[0];
         z q[0];
         h q[0];
         i q[0];
@@ -760,6 +763,11 @@ include("dm_simulator.jl")
         #pragma braket result density_matrix
         #pragma braket result probability
         #pragma braket result expectation x(q[0])
+        #pragma braket result expectation x(q[0]) @ x(q[1])
+        #pragma braket result expectation z(q[0]) @ z(q[1])
+        #pragma braket result expectation y(q[0]) @ y(q[1])
+        #pragma braket result expectation h(q[0]) @ h(q[1])
+        #pragma braket result expectation i(q[0]) @ i(q[1])
         #pragma braket result variance x(q[0]) @ y(q[1])
         """
     dm_exact_results_qasm = """
@@ -774,12 +782,16 @@ include("dm_simulator.jl")
         """
     shots_results_qasm = """
         OPENQASM 3.0;
-        qubit[2] q;
+        qubit[10] q;
         h q;
         #pragma braket result probability
         #pragma braket result expectation x(q[0])
         #pragma braket result variance x(q[0]) @ y(q[1])
         #pragma braket result sample x(q[0]) @ y(q[1])
+        #pragma braket result expectation z(q[2]) @ z(q[3])
+        #pragma braket result expectation x(q[4]) @ x(q[5])
+        #pragma braket result expectation y(q[6]) @ y(q[7])
+        #pragma braket result expectation h(q[8]) @ h(q[9])
         """
     @compile_workload begin
         using BraketSimulator, Quasar

--- a/src/BraketSimulator.jl
+++ b/src/BraketSimulator.jl
@@ -78,6 +78,8 @@ include("noise_kernels.jl")
 
 function __init__()
     Quasar.builtin_gates[] = builtin_gates
+    Quasar.parse_pragma[]  = parse_pragma
+    Quasar.visit_pragma[]  = visit_pragma
 end
 
 const LOG2_CHUNK_SIZE = 10
@@ -782,6 +784,8 @@ include("dm_simulator.jl")
     @compile_workload begin
         using BraketSimulator, Quasar
         Quasar.builtin_gates[] = BraketSimulator.builtin_gates
+        Quasar.parse_pragma[]  = BraketSimulator.parse_pragma
+        Quasar.visit_pragma[]  = BraketSimulator.visit_pragma
         simulator = StateVectorSimulator(5, 0)
         oq3_program = OpenQasmProgram(braketSchemaHeader("braket.ir.openqasm.program", "1"), custom_qasm, nothing)
         simulate(simulator, oq3_program, 100)

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -169,11 +169,12 @@ function basis_rotation_instructions!(c::Circuit)
         c.basis_rotation_instructions = reduce(vcat, _observable_to_instruction(all_qubit_observable, target) for target in qubits(c))
         return c
     end
-    unsorted = collect(Set(values(c.qubit_observable_target_mapping)))
-    target_lists = sort(unsorted)
+    mapping_vals = collect(values(c.qubit_observable_target_mapping))
+    target_lists = unique(mapping_vals)
     for target_list in target_lists
-        observable = c.qubit_observable_mapping[first(target_list)]
-        append!(basis_rotation_instructions, _observable_to_instruction(observable, target_list))
+        observable    = c.qubit_observable_mapping[first(target_list)]
+        observable_ix = _observable_to_instruction(observable, target_list)
+        append!(basis_rotation_instructions, observable_ix)
     end
     c.basis_rotation_instructions = basis_rotation_instructions
     return c

--- a/src/gates.jl
+++ b/src/gates.jl
@@ -112,7 +112,7 @@ mutable struct Unitary <: Gate
     Unitary(matrix::Matrix{<:Number}, pow_exponent=1.0) = new(ComplexF64.(matrix), Float64(pow_exponent))
 end
 Base.:(==)(u1::Unitary, u2::Unitary) = u1.matrix == u2.matrix && u1.pow_exponent == u2.pow_exponent
-qubit_count(g::Unitary) = convert(Int, log2(size(g.matrix, 1)))
+qubit_count(g::Unitary) = qubit_count(g.matrix)
 StructTypes.constructfrom(::Type{Unitary}, nt::Quasar.CircuitInstruction) = Unitary(only(nt.arguments), nt.exponent)
 
 Parametrizable(g::AngledGate) = Parametrized()

--- a/src/observables.jl
+++ b/src/observables.jl
@@ -71,7 +71,7 @@ HermitianObservable(v::Vector{Vector{Vector{T}}}) where {T<:Number} = HermitianO
 Base.copy(o::HermitianObservable) = HermitianObservable(copy(o.matrix))
 StructTypes.lower(x::HermitianObservable) = Union{String, Vector{Vector{Vector{Float64}}}}[complex_matrix_to_ir(ComplexF64.(x.matrix))]
 Base.:(==)(h1::HermitianObservable, h2::HermitianObservable) = (size(h1.matrix) == size(h2.matrix) && h1.matrix ≈ h2.matrix)
-qubit_count(o::HermitianObservable) = convert(Int, log2(size(o.matrix, 1)))
+qubit_count(o::HermitianObservable) = qubit_count(o.matrix) 
 LinearAlgebra.eigvals(o::HermitianObservable) = eigvals(Hermitian(o.matrix))
 unscaled(o::HermitianObservable) = o
 Base.:(*)(o::HermitianObservable, n::Real) = HermitianObservable(Float64(n) .* o.matrix)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -21,6 +21,8 @@ StructTypes.StructType(::Type{QuantumOperator}) = StructTypes.AbstractType()
 StructTypes.subtypes(::Type{QuantumOperator}) = (h=H, i=I, x=X, y=Y, z=Z, s=S, si=Si, t=T, ti=Ti, v=V, vi=Vi, cnot=CNot, swap=Swap, iswap=ISwap, cv=CV, cy=CY, cz=CZ, ecr=ECR, ccnot=CCNot, cswap=CSwap, unitary=Unitary, rx=Rx, ry=Ry, rz=Rz, phaseshift=PhaseShift, pswap=PSwap, xy=XY, cphaseshift=CPhaseShift, cphaseshift00=CPhaseShift00, cphaseshift01=CPhaseShift01, cphaseshift10=CPhaseShift10, xx=XX, yy=YY, zz=ZZ, gpi=GPi, gpi2=GPi2, ms=MS, prx=PRx, u=U, gphase=GPhase, kraus=Kraus, bit_flip=BitFlip, phase_flip=PhaseFlip, pauli_channel=PauliChannel, amplitude_damping=AmplitudeDamping, phase_damping=PhaseDamping, depolarizing=Depolarizing, two_qubit_dephasing=TwoQubitDephasing, two_qubit_depolarizing=TwoQubitDepolarizing, generalized_amplitude_damping=GeneralizedAmplitudeDamping, multi_qubit_pauli_channel=MultiQubitPauliChannel, measure=Measure, reset=Reset, barrier=Barrier, delay=Delay)
 parameters(::QuantumOperator) = FreeParameter[]
 
+qubit_count(o::Matrix) = Int(log2(size(o, 1))) 
+
 struct PauliEigenvalues{N}
     coeff::Float64
     PauliEigenvalues{N}(coeff::Float64=1.0) where {N} = new(coeff)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test, Aqua, Documenter, BraketSimulator
 
-Aqua.test_all(BraketSimulator, ambiguities=false, piracies=false)
+Aqua.test_all(BraketSimulator, ambiguities=false)
 Aqua.test_ambiguities(BraketSimulator)
 dir_list = filter(x-> startswith(x, "test_") && endswith(x, ".jl"), readdir(@__DIR__))
 

--- a/test/test_openqasm3.jl
+++ b/test/test_openqasm3.jl
@@ -762,9 +762,7 @@ get_tol(shots::Int) = return (
             qubit[3] q;
             i q;
             #pragma braket result expectation x(q[2])
-            // # noqa: E501
             #pragma braket result expectation hermitian([[-6+0im, 2+1im, -3+0im, -5+2im], [2-1im, 0im, 2-1im, -5+4im], [-3+0im, 2+1im, 0im, -4+3im], [-5-2im, -5-4im, -4-3im, -6+0im]]) q[0:1]
-            // # noqa: E501
             #pragma braket result expectation x(q[2]) @ hermitian([[-6+0im, 2+1im, -3+0im, -5+2im], [2-1im, 0im, 2-1im, -5+4im], [-3+0im, 2+1im, 0im, -4+3im], [-5-2im, -5-4im, -4-3im, -6+0im]]) q[0:1]
             """
             circuit = BraketSimulator.to_circuit(qasm) 
@@ -773,7 +771,8 @@ get_tol(shots::Int) = return (
                     2-1im 0 2-1im -5+4im;
                    -3 2+1im 0 -4+3im;
                    -5-2im -5-4im -4-3im -6]
-            h = BraketSimulator.Observables.HermitianObservable(arr)
+            h    = BraketSimulator.Observables.HermitianObservable(arr)
+            @test circuit.result_types[2].observable.matrix == arr
             bris = vcat(BraketSimulator.diagonalizing_gates(h, [0, 1]), BraketSimulator.Instruction(BraketSimulator.H(), [2]))
             for (ix, bix) in zip(circuit.basis_rotation_instructions, bris)
                 @test Matrix(BraketSimulator.matrix_rep(ix.operator)) ≈ adjoint(BraketSimulator.fix_endianness(Matrix(BraketSimulator.matrix_rep(bix.operator))))


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Add a few things to precompilation to trigger it for various `TensorProduct` combinations.
- Update the pragma parsing to the newer way of doing this in Quasar 0.0.2 and bump dependency version
- Other small cleanups

*Testing done:*
- Unit tests pass locally
- Benchmarking in Julia and Python shows this improves "time to first simulation" for QFT, QAOA
- Tests in Python wrapper pass (PR there coming soon)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/README.md) and [API docs](https://github.com/amazon-braket/BraketSimulator.jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
